### PR TITLE
Railcraft pollution fix + changes

### DIFF
--- a/src/main/kotlin/com/github/bartimaeusnek/modmixins/core/LoadingConfig.kt
+++ b/src/main/kotlin/com/github/bartimaeusnek/modmixins/core/LoadingConfig.kt
@@ -14,9 +14,13 @@ object LoadingConfig {
         fixRocketPollution = config["fixes", "fixRocketPollution", true, "Adds Pollution to every rocket start"].boolean
         fixZtonesNetworkVulnerability = config["fixes", "fixZtonesNetworkVulnerability", true, "Fixes Ztones Network Vulnerability"].boolean
         fixTimeCommandGc = config["fixes", "fixTimeCommandGc", true, "Fixes GC Time Command without creating lag"].boolean
-        rocketPollution = config["options","rocketPollution", 10000, "Pollution when starting per tick, min 1!", 1 , Int.MAX_VALUE].int
-        furnacePollution = config["options","furnacePollution", 1, "Pollution per tick, min 1!", 1 , Int.MAX_VALUE].int
+        rocketPollution = config["options","rocketPollution", 10000, "Pollution when starting per second, min 1!", 1 , Int.MAX_VALUE].int
+        furnacePollution = config["options","furnacePollution", 20, "Furnace pollution per second, min 1!", 1 , Int.MAX_VALUE].int
         explosionPollution = config["options","explosionPollution", 333.34, "Explosion one time pollution"].double.toFloat()
+        cokeOvenPollution = config["options", "cokeOvenPollution", 3, "Coke oven pollution per second, min 1!", 1, Int.MAX_VALUE].int
+        advancedCokeOvenPollution = config["options", "advancedCokeOvenPollution", 80, "Advanced coke oven pollution per second, min 1!", 1, Int.MAX_VALUE].int
+        fireboxPollution = config["options", "fireboxPollution", 15, "Railcraft boiler firebox pollution per second, min 1!", 1, Int.MAX_VALUE].int
+        hobbyistEnginePollution = config ["options", "hobbyistEnginePollution", 20, "Hobbyist's steam engine pollution per second, min 1!", 1, Int.MAX_VALUE].int
 
         if (config.hasChanged())
             config.save()
@@ -30,7 +34,11 @@ object LoadingConfig {
     var fixThaumcraftFurnacePollution : Boolean = false
     var fixExplosionPollution : Boolean = false
     var fixZtonesNetworkVulnerability : Boolean = false
-    var furnacePollution : Int = 1
+    var furnacePollution : Int = 20
     var rocketPollution : Int = 1
     var explosionPollution : Float = 333.34f
+    var cokeOvenPollution : Int = 3;
+    var fireboxPollution : Int = 15;
+    var advancedCokeOvenPollution: Int = 80;
+    var hobbyistEnginePollution: Int = 20;
 }

--- a/src/main/kotlin/com/github/bartimaeusnek/modmixins/main/ModMixinsMod.kt
+++ b/src/main/kotlin/com/github/bartimaeusnek/modmixins/main/ModMixinsMod.kt
@@ -76,10 +76,10 @@ object ModMixinsMod {
 
                 if (LoadingConfig.fixRailcraftBoilerPollution && Loader.isModLoaded("Railcraft")) {
                     val multi = "A complete Multiblock "
-                    val boilerPollution = "Produces 40 Pollution/Second"
+                    val boilerPollution = "Produces 15 Pollution/Second per firebox"
                     val steamEnginePollution = "Produces 20 Pollution/Second"
                     val blastFurnacePollution = multi+"produces ${LoadingConfig.furnacePollution * 4 * 20} Pollution/Second"
-                    val cokeOfenPollution = multi+"produces ${LoadingConfig.furnacePollution * 20} Pollution/Second"
+                    val cokeOfenPollution = multi+"produces 3 Pollution/Second"
                     when {
                         GT_Utility.areStacksEqual(it, ItemStack(RailcraftBlocks.getBlockMachineBeta(), 1, EnumMachineBeta.BOILER_FIREBOX_SOLID.ordinal)) -> {
                             event.toolTip += boilerPollution

--- a/src/main/kotlin/com/github/bartimaeusnek/modmixins/main/ModMixinsMod.kt
+++ b/src/main/kotlin/com/github/bartimaeusnek/modmixins/main/ModMixinsMod.kt
@@ -57,7 +57,7 @@ object ModMixinsMod {
             event?.itemStack?.also{
 
                 if (LoadingConfig.fixVanillaFurnacePollution){
-                    val furnacePollution = "Produces ${LoadingConfig.furnacePollution*20} Pollution/Second"
+                    val furnacePollution = "Produces ${LoadingConfig.furnacePollution} Pollution/Second"
                     when {
                         GT_Utility.areStacksEqual(it, ItemStack(Blocks.furnace)) -> {
                             event.toolTip += furnacePollution
@@ -76,10 +76,10 @@ object ModMixinsMod {
 
                 if (LoadingConfig.fixRailcraftBoilerPollution && Loader.isModLoaded("Railcraft")) {
                     val multi = "A complete Multiblock "
-                    val boilerPollution = "Produces 15 Pollution/Second per firebox"
-                    val steamEnginePollution = "Produces 20 Pollution/Second"
-                    val blastFurnacePollution = multi+"produces ${LoadingConfig.furnacePollution * 4 * 20} Pollution/Second"
-                    val cokeOfenPollution = multi+"produces 3 Pollution/Second"
+                    val boilerPollution = "Produces ${LoadingConfig.fireboxPollution} Pollution/Second per firebox"
+                    val steamEnginePollution = "Produces ${LoadingConfig.hobbyistEnginePollution} Pollution/Second"
+                    val blastFurnacePollution = multi+"produces ${LoadingConfig.advancedCokeOvenPollution} Pollution/Second"
+                    val cokeOfenPollution = multi+"produces ${LoadingConfig.cokeOvenPollution} Pollution/Second"
                     when {
                         GT_Utility.areStacksEqual(it, ItemStack(RailcraftBlocks.getBlockMachineBeta(), 1, EnumMachineBeta.BOILER_FIREBOX_SOLID.ordinal)) -> {
                             event.toolTip += boilerPollution
@@ -106,8 +106,8 @@ object ModMixinsMod {
                     it.item::class.simpleName?.also { spln ->
                         if (spln.contains("Rocket")){
                             spln.find{d -> d.isDigit()}?.also { num ->
-                                event.toolTip += "Produces ${NumberFormat.getNumberInstance().format((LoadingConfig.rocketPollution shl Character.getNumericValue(num)) / 100)} Pollution/Second when ignited"
-                                event.toolTip += "Produces ${NumberFormat.getNumberInstance().format((LoadingConfig.rocketPollution shl Character.getNumericValue(num)))} Pollution/Second when flying"
+                                event.toolTip += "Produces ${NumberFormat.getNumberInstance().format((LoadingConfig.rocketPollution shl (Character.getNumericValue(num) - 1)) / 100)} Pollution/Second when ignited"
+                                event.toolTip += "Produces ${NumberFormat.getNumberInstance().format(LoadingConfig.rocketPollution shl (Character.getNumericValue(num) - 1))} Pollution/Second when flying"
                             }
                         }
                     }

--- a/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/galacticraft/entity/RocketPollutionAdder.kt
+++ b/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/galacticraft/entity/RocketPollutionAdder.kt
@@ -16,11 +16,11 @@ abstract class RocketPollutionAdder(world: World) : EntityAutoRocket(world), IRo
 
     @Inject(method = ["onUpdate"],at =  [At("HEAD")])
     fun addRocketStartPollution(x: CallbackInfo) {
-        if (!this.worldObj.isRemote && (this.launchPhase == EnumLaunchPhase.LAUNCHED.ordinal || this.launchPhase == EnumLaunchPhase.IGNITED.ordinal)){
+        if (!this.worldObj.isRemote && (this.launchPhase == EnumLaunchPhase.LAUNCHED.ordinal || this.launchPhase == EnumLaunchPhase.IGNITED.ordinal) && (this.worldObj.totalWorldTime % 20).toInt() == 0){
              GT_Pollution.addPollution(this.worldObj.getChunkFromBlockCoords(this.posX.toInt(),this.posZ.toInt()),
                      when (this.launchPhase){
-                         EnumLaunchPhase.LAUNCHED.ordinal -> (LoadingConfig.rocketPollution shl this.rocketTier) / 20
-                         EnumLaunchPhase.IGNITED.ordinal -> (LoadingConfig.rocketPollution shl this.rocketTier) / 20 / 100
+                         EnumLaunchPhase.LAUNCHED.ordinal -> (LoadingConfig.rocketPollution shl (this.rocketTier - 1))
+                         EnumLaunchPhase.IGNITED.ordinal -> (LoadingConfig.rocketPollution shl (this.rocketTier - 1)) / 100
                          else -> 0
                      }
              )

--- a/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/ic2/tileentity/IronFurnacePollution.kt
+++ b/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/ic2/tileentity/IronFurnacePollution.kt
@@ -18,7 +18,7 @@ class IronFurnacePollution : TileEntity() {
 
     @Inject(method = ["updateEntityServer"], at = [At(value = "TAIL")])
     fun updateEntityServer(c: CallbackInfo) {
-        if (!this.worldObj.isRemote && this.isBurning()) {
+        if (!this.worldObj.isRemote && this.isBurning() && (this.worldObj.totalWorldTime % 20).toInt() == 0) {
             GT_Pollution.addPollution(this.worldObj!!.getChunkFromBlockCoords(this.xCoord, this.zCoord), LoadingConfig.furnacePollution)
         }
     }

--- a/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/railcraft/boiler/RailcraftBoilerPollution.kt
+++ b/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/railcraft/boiler/RailcraftBoilerPollution.kt
@@ -24,12 +24,13 @@ class RailcraftBoilerPollution {
     fun tick(x: Int, c: CallbackInfo) {
         if (this.isBurning)
             tile?.also {
-                if (!it.world.isRemote)
+                if (!it.world.isRemote && (it.worldObj.totalWorldTime % 20).toInt() == 0) {
                     GT_Pollution.addPollution(it.world.getChunkFromBlockCoords(it.x, it.z), when (it) {
-                        is TileMultiBlock -> (it.components.size - x) * 2
-                        is TileEngineSteamHobby -> 1
-                        else -> 2
-                })
+                        is TileMultiBlock -> (it.components.size - x) * 15
+                        is TileEngineSteamHobby -> 20
+                        else -> 40
+                    })
+                }
             }
     }
 }

--- a/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/railcraft/boiler/RailcraftBoilerPollution.kt
+++ b/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/railcraft/boiler/RailcraftBoilerPollution.kt
@@ -1,5 +1,6 @@
 package com.github.bartimaeusnek.modmixins.mixins.railcraft.boiler
 
+import com.github.bartimaeusnek.modmixins.core.LoadingConfig
 import gregtech.common.GT_Pollution
 import mods.railcraft.common.blocks.RailcraftTileEntity
 import mods.railcraft.common.blocks.machine.TileMultiBlock
@@ -26,8 +27,8 @@ class RailcraftBoilerPollution {
             tile?.also {
                 if (!it.world.isRemote && (it.worldObj.totalWorldTime % 20).toInt() == 0) {
                     GT_Pollution.addPollution(it.world.getChunkFromBlockCoords(it.x, it.z), when (it) {
-                        is TileMultiBlock -> (it.components.size - x) * 15
-                        is TileEngineSteamHobby -> 20
+                        is TileMultiBlock -> (it.components.size - x) * LoadingConfig.fireboxPollution
+                        is TileEngineSteamHobby -> LoadingConfig.hobbyistEnginePollution
                         else -> 40
                     })
                 }

--- a/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/railcraft/boiler/RailcraftBoilerPollution.kt
+++ b/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/railcraft/boiler/RailcraftBoilerPollution.kt
@@ -26,7 +26,7 @@ class RailcraftBoilerPollution {
             tile?.also {
                 if (!it.world.isRemote)
                     GT_Pollution.addPollution(it.world.getChunkFromBlockCoords(it.x, it.z), when (it) {
-                        is TileMultiBlock -> it.components.size * 2
+                        is TileMultiBlock -> (it.components.size - x) * 2
                         is TileEngineSteamHobby -> 1
                         else -> 2
                 })

--- a/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/railcraft/tileentity/MultiOfenPollution.kt
+++ b/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/railcraft/tileentity/MultiOfenPollution.kt
@@ -20,10 +20,10 @@ abstract class MultiOfenPollution(patterns: MutableList<MultiBlockPattern>) : Ti
 
     @Inject(method = ["updateEntity"], at = [At("HEAD")])
     fun addPollution(c: CallbackInfo) {
-        if (!this.worldObj.isRemote && this.cooking && this.isMaster){
+        if (!this.worldObj.isRemote && this.cooking && this.isMaster && (this.worldObj.totalWorldTime % 20).toInt() == 0){
             GT_Pollution.addPollution(this.worldObj.getChunkFromBlockCoords(this.xCoord, this.zCoord), when (this) {
-                is TileBlastFurnace -> LoadingConfig.furnacePollution * 4
-                else -> LoadingConfig.furnacePollution
+                is TileBlastFurnace -> LoadingConfig.furnacePollution * 4 * 20
+                else -> 3
             })
         }
     }

--- a/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/railcraft/tileentity/MultiOfenPollution.kt
+++ b/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/railcraft/tileentity/MultiOfenPollution.kt
@@ -22,8 +22,8 @@ abstract class MultiOfenPollution(patterns: MutableList<MultiBlockPattern>) : Ti
     fun addPollution(c: CallbackInfo) {
         if (!this.worldObj.isRemote && this.cooking && this.isMaster && (this.worldObj.totalWorldTime % 20).toInt() == 0){
             GT_Pollution.addPollution(this.worldObj.getChunkFromBlockCoords(this.xCoord, this.zCoord), when (this) {
-                is TileBlastFurnace -> LoadingConfig.furnacePollution * 4 * 20
-                else -> 3
+                is TileBlastFurnace -> LoadingConfig.advancedCokeOvenPollution
+                else -> LoadingConfig.cokeOvenPollution
             })
         }
     }

--- a/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/thaumcraft/tileentity/AlchemicalConstructPollutionAdder.kt
+++ b/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/thaumcraft/tileentity/AlchemicalConstructPollutionAdder.kt
@@ -15,7 +15,7 @@ class AlchemicalConstructPollutionAdder : TileEntity() {
 
     @Inject(method = ["updateEntity"], at = [At(value = "FIELD", target = "thaumcraft/common/tiles/TileAlchemyFurnace.furnaceBurnTime:I", opcode = Opcodes.PUTFIELD, remap = false)])
     fun addPollution(c: CallbackInfo) {
-        if (!this.worldObj.isRemote)
+        if (!this.worldObj.isRemote && (this.worldObj.totalWorldTime % 20).toInt() == 0)
             GT_Pollution.addPollution(this.worldObj!!.getChunkFromBlockCoords(this.xCoord, this.zCoord), LoadingConfig.furnacePollution)
     }
 

--- a/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/vanilla/tileentity/TileEntityFurnacePollution.kt
+++ b/src/main/kotlin/com/github/bartimaeusnek/modmixins/mixins/vanilla/tileentity/TileEntityFurnacePollution.kt
@@ -15,7 +15,7 @@ class TileEntityFurnacePollution : TileEntity() {
 
     @Inject(method = ["updateEntity"], at = [At(value = "FIELD", target = "net/minecraft/tileentity/TileEntityFurnace.furnaceBurnTime:I", opcode = PUTFIELD)])
     fun addPollution(c: CallbackInfo){
-        if (!this.worldObj.isRemote)
+        if (!this.worldObj.isRemote && (this.worldObj.totalWorldTime % 20).toInt() == 0)
             GT_Pollution.addPollution(this.worldObj!!.getChunkFromBlockCoords(this.xCoord, this.zCoord), LoadingConfig.furnacePollution)
     }
 }


### PR DESCRIPTION
-Boilers were creating pollution multiplied by the total blocks in the structure. This has been changed to be only the fireboxes.
-Firebox pollution 40->15, coke oven pollution 20->3
-Added config for each pollution value individually, and changed all the config values to per second rather than per tick
-Fixed issue where rockets were treated as 1 tier too high, with t1 rocket producing double the config base value. This halves the pollution that all rockets currently do. So if it is deemed necessary to change this back to the previous values, the rocket pollution config value should be changed to 20000

-I couldn't find a way to make liquid and solid fireboxes produce different amounts, but I think this is relatively unimportant